### PR TITLE
Dockerfile.jre11: improve dnf commands, fix broken update

### DIFF
--- a/build/Dockerfile.jre11
+++ b/build/Dockerfile.jre11
@@ -2,8 +2,7 @@ FROM quay.io/sysdig/sysdig-ubi:1.1.8 as sysdig-ubi-jre
 
 USER root
 
-RUN dnf update
-RUN dnf install -y java-11-openjdk-headless.x86_64
+RUN dnf update -y && dnf install -y java-11-openjdk-headless.x86_64 && dnf clean all
 
 FROM maven:3.6.3-openjdk as javabuilder
 


### PR DESCRIPTION
Fixes the `dnf update` command by supplying a `-y` argument. Also bundles the java jre install and update together, along with a dnf clean for a smaller, cleaner image.